### PR TITLE
Add gcp deploy for go codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,15 @@
 
 The Kops-cli provides the functionality to deploy your applications seamlessly on 
 cloud using kops - simplified devops.
+
+To install the cli app run the following command
+```
+go install kops.dev@latest //to get the latest release for kops cli
+```
+
+or clone the repo and build binary
+```bash
+git clone https://github.com/kops-dev/kops-cli
+
+go build -o kops.dev .
+```

--- a/deploy.go
+++ b/deploy.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"gofr.dev/pkg/gofr"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"kops.dev/internal/models"
+)
+
+const (
+	gcp            = "GCP"
+	executableName = "main"
+)
+
+var (
+	buildFlags = fmt.Sprintf("CGO_ENABLED=0 GOOS=%s GOARCH=%s", runtime.GOOS, runtime.GOARCH)
+)
+
+func Deploy(ctx *gofr.Context) (interface{}, error) {
+	var deploy models.Deploy
+
+	keyFile := os.Getenv("KOPS_DEPLOYMENT_KEY")
+	if keyFile == "" {
+		return nil, errors.New("KOPS_DEPLOYMENT_KEY not provided, please download the key form https://kops.dev")
+	}
+
+	f, err := os.ReadFile(filepath.Clean(keyFile))
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(f, &deploy)
+	if err != nil {
+		return nil, err
+	}
+
+	// build binaries for the current working directory
+	err = buildBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	// create and build docker image
+	err = createGoDockerFile()
+	if err != nil {
+		return nil, err
+	}
+
+	tag := ctx.Param("tag")
+	if tag == "" {
+		tag = "latest"
+	}
+
+	cmd := exec.Command("docker", "build", "-t"+deploy.ServiceName+":"+tag, ".")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+
+	// check what cloud provider is
+	switch deploy.CloudProvider {
+	default:
+		err = deployGCP(&deploy, "")
+		if err != nil {
+			return nil, err
+		}
+
+		return "Successfully deployed!", nil
+	}
+}
+
+func buildBinary() error {
+	cmd := exec.Command("sh", "-c", buildFlags+" go build -o "+executableName+" .")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error executing command: %s, %v", output, err)
+	}
+
+	fmt.Println("Binary created successfully")
+
+	return nil
+}
+
+func createGoDockerFile() error {
+	content := fmt.Sprintf(`FROM alpine:latest
+RUN apk add --no-cache tzdata ca-certificates
+COPY main ./main
+RUN chmod +x /main
+EXPOSE 8000
+CMD ["/main"]`)
+
+	fi, _ := os.Stat("Dockerfile")
+	if fi != nil {
+		fmt.Println("Dockerfile present, using already created dockerfile")
+		return nil
+	}
+
+	file, err := os.Create("Dockerfile")
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	if _, err = file.WriteString(content); err != nil {
+		return err
+	}
+
+	fmt.Println("Dockerfile created successfully!")
+	return nil
+}

--- a/deploy.go
+++ b/deploy.go
@@ -57,7 +57,8 @@ func Deploy(ctx *gofr.Context) (interface{}, error) {
 		tag = "latest"
 	}
 
-	cmd := exec.Command("docker", "build", "-t"+deploy.ServiceName+":"+tag, ".")
+	image := deploy.ServiceName + ":" + tag
+	cmd := exec.Command("docker", "build", "-t"+image, ".")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
@@ -68,7 +69,7 @@ func Deploy(ctx *gofr.Context) (interface{}, error) {
 	// check what cloud provider is
 	switch deploy.CloudProvider {
 	default:
-		err = deployGCP(&deploy, "")
+		err = deployGCP(&deploy, image)
 		if err != nil {
 			return nil, err
 		}

--- a/gcp.go
+++ b/gcp.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"kops.dev/internal/models"
+	"os"
+	"os/exec"
+)
+
+var (
+	errInvalidKey = errors.New("")
+)
+
+func deployGCP(gcp *models.Deploy, imageName string) error {
+	var key models.GoogleCred
+
+	jsonBytes, err := json.MarshalIndent(gcp.Key, "", " ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, err.Error())
+
+		return errInvalidKey
+	}
+
+	// checks if the converted json data is valid
+	err = json.Unmarshal(jsonBytes, &key)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, err.Error())
+
+		return errInvalidKey
+	}
+
+	err = os.WriteFile("application_creds.json", jsonBytes, 0644)
+	if err != nil {
+		return err
+	}
+
+	// Authenticate using gcloud
+	cmd := exec.Command("gcloud", "auth", "activate-service-account", "--key-file=./application_creds.json")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println(string(out))
+
+		return err
+	}
+
+	fmt.Println(string(out))
+
+	defer func() {
+		fmt.Println("removing application credentials")
+		os.Remove("application_creds.json")
+	}()
+
+	return nil
+}

--- a/gcp.go
+++ b/gcp.go
@@ -4,111 +4,115 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"kops.dev/internal/models"
 	"os"
 	"os/exec"
+
+	"kops.dev/internal/models"
 )
+
+const filePerm = 0644
 
 var (
 	errInvalidKey = errors.New("")
 )
 
 func deployGCP(gcp *models.Deploy, imageName string) error {
-	var key models.GoogleCred
+	var key = models.GCPInfo{}
 
 	jsonBytes, err := json.MarshalIndent(gcp.Key, "", " ")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, err.Error())
+		fmt.Println(err.Error())
 
 		return errInvalidKey
 	}
 
-	// checks if the converted json data is valid
-	err = json.Unmarshal(jsonBytes, &key)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, err.Error())
-
-		return errInvalidKey
-	}
-
-	err = os.WriteFile("application_creds.json", jsonBytes, 0644)
+	err = authenticateCLI(jsonBytes, &key)
 	if err != nil {
 		return err
 	}
 
-	// Authenticate using gcloud
-	cmd := replaceInputOutput(
-		exec.Command("gcloud", "auth", "activate-service-account", "--key-file=./application_creds.json", "--project="+key.ProjectId),
-	)
-
-	err = cmd.Run()
-	if err != nil {
-		fmt.Println("Error executing command:", err)
-		return err
-	}
-
-	defer func() {
-		os.Remove("application_creds.json")
-	}()
-
-	cmd = replaceInputOutput(exec.Command("gcloud", "auth", "configure-docker", gcp.Region+"-docker.pkg.dev"))
-	err = cmd.Run()
+	err = replaceInputOutput(exec.Command("gcloud", "auth",
+		"configure-docker", gcp.Region+"-docker.pkg.dev")).Run()
 	if err != nil {
 		fmt.Println("error configuring docker registry")
 		return err
 	}
 
-	imageLoc := gcp.Region + "-docker.pkg.dev" + "/" + key.ProjectId + "/" + gcp.DockerRegistry + "/" + imageName
+	imageLoc := gcp.Region + "-docker.pkg.dev" + "/" + key.ProjectID + "/" + gcp.DockerRegistry + "/" + imageName
+	fmt.Println(imageLoc)
 
-	cmd = replaceInputOutput(
+	err = replaceInputOutput(
 		exec.Command("docker", "tag", imageName, imageLoc),
-	)
-	err = cmd.Run()
+	).Run()
 	if err != nil {
 		return err
 	}
 
-	cmd = replaceInputOutput(
+	err = replaceInputOutput(
 		exec.Command("docker", "push", imageLoc),
-	)
-	err = cmd.Run()
+	).Run()
 	if err != nil {
 		return err
 	}
 
-	cmd = exec.Command("gcloud", "container", "clusters", "get-credentials", gcp.ClusterName, "--region="+gcp.Region, "--project="+key.ProjectId)
-	err = cmd.Run()
+	err = replaceInputOutput(exec.Command("gcloud", "container", "clusters",
+		"get-credentials", gcp.ClusterName, "--region="+gcp.Region, "--project="+key.ProjectID)).Run()
 	if err != nil {
 		return err
 	}
 
-	cmd = exec.Command("kubectl", "set", "image", "deployment/"+gcp.ServiceName,
+	err = replaceInputOutput(exec.Command("kubectl", "set", "image", "deployment/"+gcp.ServiceName,
 		gcp.ServiceName+"="+imageLoc,
-		"--namespace", gcp.Namespace)
-
-	fmt.Println("kubectl", "set", "image", "deployment/"+gcp.ServiceName,
-		gcp.ServiceName+"="+imageLoc,
-		"--namespace", gcp.Namespace)
-
-	output, err := cmd.CombinedOutput()
+		"--namespace", gcp.Namespace)).Run()
 	if err != nil {
-		fmt.Println("Error executing command:", err)
-		fmt.Println("Detailed error output:", string(output))
 		return err
 	}
 
 	return nil
 }
 
-// replaceInputOutput attaches the
-func replaceInputOutput(cmd *exec.Cmd, files ...*os.File) *exec.Cmd {
-	if len(files) > 0 {
-		cmd.Stdout = files[0]
-	}
-
+// replaceInputOutput attaches the current terminal std out, err and in to cmd.
+func replaceInputOutput(cmd *exec.Cmd) *exec.Cmd {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 
 	return cmd
+}
+
+func authenticateCLI(jsonBytes []byte, info *models.GCPInfo) error {
+	var key models.GCPInfo
+
+	// checks if the converted json data is valid
+	err := json.Unmarshal(jsonBytes, &key)
+	if err != nil {
+		fmt.Println(err.Error())
+
+		return errInvalidKey
+	}
+
+	info.ProjectID = key.ProjectID
+
+	f, err := os.OpenFile("application_creds.json", os.O_CREATE|os.O_WRONLY, filePerm)
+	if err != nil {
+		return err
+	}
+
+	defer os.Remove("application_creds.json")
+
+	_, err = f.Write(jsonBytes)
+	if err != nil {
+		return err
+	}
+
+	// Authenticate using gcloud
+	err = replaceInputOutput(
+		exec.Command("gcloud", "auth",
+			"activate-service-account", "--key-file=./application_creds.json", "--project="+key.ProjectID)).Run()
+	if err != nil {
+		fmt.Println("Error executing command:", err)
+		return err
+	}
+
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kops.dev
 
-go 1.21
+go 1.22
 
 require gofr.dev v1.10.0
 

--- a/internal/models/deployment.go
+++ b/internal/models/deployment.go
@@ -10,16 +10,6 @@ type Deploy struct {
 	Key            interface{} `json:"key"`
 }
 
-type GoogleCred struct {
-	AuthProviderX509CertUrl string `json:"auth_provider_x509_cert_url"`
-	AuthUri                 string `json:"auth_uri"`
-	ClientEmail             string `json:"client_email"`
-	ClientId                string `json:"client_id"`
-	ClientX509CertUrl       string `json:"client_x509_cert_url"`
-	PrivateKey              string `json:"private_key"`
-	PrivateKeyId            string `json:"private_key_id"`
-	ProjectId               string `json:"project_id"`
-	TokenUri                string `json:"token_uri"`
-	Type                    string `json:"type"`
-	UniverseDomain          string `json:"universe_domain"`
+type GCPInfo struct {
+	ProjectID string `json:"project_id"`
 }

--- a/internal/models/deployment.go
+++ b/internal/models/deployment.go
@@ -1,11 +1,13 @@
 package models
 
 type Deploy struct {
-	ClusterName   string      `json:"cluster_name"`
-	Region        string      `json:"region"`
-	ServiceName   string      `json:"service_name"`
-	CloudProvider string      `json:"cloud_provider"`
-	Key           interface{} `json:"key"`
+	ClusterName    string      `json:"cluster_name"`
+	Region         string      `json:"region"`
+	ServiceName    string      `json:"service_name"`
+	CloudProvider  string      `json:"cloud_provider"`
+	Namespace      string      `json:"namespace"`
+	DockerRegistry string      `json:"docker_registry"`
+	Key            interface{} `json:"key"`
 }
 
 type GoogleCred struct {

--- a/internal/models/deployment.go
+++ b/internal/models/deployment.go
@@ -1,0 +1,23 @@
+package models
+
+type Deploy struct {
+	ClusterName   string      `json:"cluster_name"`
+	Region        string      `json:"region"`
+	ServiceName   string      `json:"service_name"`
+	CloudProvider string      `json:"cloud_provider"`
+	Key           interface{} `json:"key"`
+}
+
+type GoogleCred struct {
+	AuthProviderX509CertUrl string `json:"auth_provider_x509_cert_url"`
+	AuthUri                 string `json:"auth_uri"`
+	ClientEmail             string `json:"client_email"`
+	ClientId                string `json:"client_id"`
+	ClientX509CertUrl       string `json:"client_x509_cert_url"`
+	PrivateKey              string `json:"private_key"`
+	PrivateKeyId            string `json:"private_key_id"`
+	ProjectId               string `json:"project_id"`
+	TokenUri                string `json:"token_uri"`
+	Type                    string `json:"type"`
+	UniverseDomain          string `json:"universe_domain"`
+}

--- a/main.go
+++ b/main.go
@@ -9,5 +9,7 @@ func main() {
 		return "kops cli version " + version, nil
 	}, gofr.AddDescription("displays the installed kops version"))
 
+	app.SubCommand("deploy", Deploy)
+
 	app.Run()
 }

--- a/main.go
+++ b/main.go
@@ -9,7 +9,8 @@ func main() {
 		return "kops cli version " + version, nil
 	}, gofr.AddDescription("displays the installed kops version"))
 
-	app.SubCommand("deploy", Deploy)
+	app.SubCommand("deploy", Deploy,
+		gofr.AddDescription("builds and deploy code using a single command"))
 
 	app.Run()
 }


### PR DESCRIPTION
usages added - `deploy` command - builds and deploys go code to an existing gcp account using service account key generated from kops.dev UI/API